### PR TITLE
[feat] GPT API 호출 및 응답 기능

### DIFF
--- a/src/main/java/com/nuri/nuribackend/NuriBackendApplication.java
+++ b/src/main/java/com/nuri/nuribackend/NuriBackendApplication.java
@@ -2,6 +2,8 @@ package com.nuri.nuribackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class NuriBackendApplication {
@@ -9,5 +11,8 @@ public class NuriBackendApplication {
     public static void main(String[] args) {
         SpringApplication.run(NuriBackendApplication.class, args);
     }
-
+    @Bean
+    public RestTemplate restTemplate(){
+        return new RestTemplate();
+    }
 }

--- a/src/main/java/com/nuri/nuribackend/config/GPTConfig.java
+++ b/src/main/java/com/nuri/nuribackend/config/GPTConfig.java
@@ -1,0 +1,22 @@
+package com.nuri.nuribackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+public class GPTConfig {
+    @Value("${openai.api.key}")
+    private String apiKey;
+    @Bean
+    public RestTemplate restTemplate(){
+        RestTemplate template = new RestTemplate();
+        template.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add(
+                    "Authorization"
+                    ,"Bearer " + apiKey);
+            return execution.execute(request,body);
+        });
+        return template;
+    }
+}

--- a/src/main/java/com/nuri/nuribackend/dto/GPT/GPTRequest.java
+++ b/src/main/java/com/nuri/nuribackend/dto/GPT/GPTRequest.java
@@ -1,0 +1,37 @@
+package com.nuri.nuribackend.dto.GPT;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+
+public class GPTRequest {
+    private String model;
+    private List<Map<String, String>>  messages;
+    private int temperature;
+    private int maxTokens;
+    private int topP;
+    private int frequencyPenalty;
+    private int presencePenalty;
+
+    // 생성자
+    public GPTRequest(String model, List<Map<String, String>>  messages, int temperature, int maxTokens, int topP, int frequencyPenalty, int presencePenalty) {
+        this.model = model;
+        this.messages = messages;
+        this.temperature = temperature;
+        this.maxTokens = maxTokens;
+        this.topP = topP;
+        this.frequencyPenalty = frequencyPenalty;
+        this.presencePenalty = presencePenalty;
+    }
+
+    // Getter, Setter
+}
+

--- a/src/main/java/com/nuri/nuribackend/dto/GPT/GPTResponse.java
+++ b/src/main/java/com/nuri/nuribackend/dto/GPT/GPTResponse.java
@@ -1,0 +1,22 @@
+package com.nuri.nuribackend.dto.GPT;
+
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GPTResponse {
+
+    private List<Choice> choices;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Choice {
+        private int index;
+        private Message message;
+
+    }
+}

--- a/src/main/java/com/nuri/nuribackend/dto/GPT/Message.java
+++ b/src/main/java/com/nuri/nuribackend/dto/GPT/Message.java
@@ -1,0 +1,15 @@
+package com.nuri.nuribackend.dto.GPT;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Message {
+
+    private String role;
+    private String content;
+
+}

--- a/src/main/java/com/nuri/nuribackend/service/GPTService.java
+++ b/src/main/java/com/nuri/nuribackend/service/GPTService.java
@@ -1,0 +1,91 @@
+package com.nuri.nuribackend.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nuri.nuribackend.domain.ChatMessage;
+import com.nuri.nuribackend.dto.GPT.GPTResponse;
+import com.nuri.nuribackend.repository.ChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GPTService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper mapper;
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Value("${openai.api.url}")
+    private String apiUrl;
+
+    @Value("${openai.api.model}")
+    private String model;
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    public ChatMessage handleTextGPT(String result) {
+        // 사용자 메시지 설정
+        Map<String, String> userMessage = new HashMap<>();
+        userMessage.put("role", "user");
+        userMessage.put("content", result);
+        List<Map<String, String>> messages = List.of(userMessage);
+
+        // GPT 요청 생성
+        Map<String, Object> gptRequest = Map.of(
+                "model", model,
+                "messages", messages,
+                "max_tokens", 256,
+                "temperature", 0.7,
+                "top_p", 0.7
+        );
+
+        // 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "Bearer " + apiKey);
+
+        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(gptRequest, headers);
+
+        try {
+
+            // GPT API 호출
+            GPTResponse gptResponse = restTemplate.postForObject(apiUrl, requestEntity, GPTResponse.class);
+            System.out.println("지피티 대답: " + gptResponse);
+
+            // GPT 응답 처리
+            if (gptResponse != null && gptResponse.getChoices() != null && !gptResponse.getChoices().isEmpty()) {
+
+                String gptReply = gptResponse.getChoices().get(0).getMessage().getContent();
+
+                ChatMessage chatMessage = new ChatMessage();
+                chatMessage.setMsgSound(null); // url
+                chatMessage.setMsgText(gptReply);
+                chatMessage.setMsgType("gpt");
+                chatMessage.setTimeStamp(LocalDateTime.now());
+
+                return chatMessage;
+
+            } else {
+                log.error("GPT API에서 응답이 없습니다.");
+                return null;
+            }
+            } catch (Exception e) {
+                log.error("GPT API 호출 중 오류가 발생했습니다.", e);
+                return null;
+            }
+
+    }
+}


### PR DESCRIPTION
### resolve: #11 
---

### 📝 주요 수정 사항

#### 1. **GPTService.java - GPT API 서비스 구현**
```
👽 새로 생성된 파일

핵심 메서드:

1. handleTextGPT(String result)
  - 목적: 사용자 메시지에 대한 GPT 일반 응답 생성
  - 사용자 메시지를 JSON 형식으로 구성
  - RestTemplate을 통해 OpenAI API로 POST 요청
  - 응답값을 ChatMessage 객체로 변환
  - 메시지 타입: "gpt", 타임스탬프 자동 설정

2. handleFeedbackGPT(String msgId, String msgText, String feedbackType)
  - 목적: 맞춤형 피드백 생성 (문법, 어휘, 존댓말)
  - System Prompt를 feedbackType에 따라 동적으로 설정
  - 스위치 표현식(Switch Expression)으로 명확한 분기 처리
  - 기존 피드백이 있으면 재사용, 없으면 새로 생성
  - FeedbackContent 객체로 저장하여 타입별 피드백 관리
```

#### 2. **SocketVoiceHandler.java - WebSocket 텍스트 메시지 핸들링** (수정)
```
👽 기존 파일 확장

수정 사항:
  - GPTService 의존성 주입 추가
  - handleTextMessage() 메서드에서 TextMessage 처리
  - JSON 페이로드를 FeedbackMessage DTO로 파싱
  - msgText, msgId, feedbackType 추출
  - gptService.handleFeedbackGPT() 호출로 피드백 생성
  - feedbackType에 따라 해당 피드백만 필터링하여 클라이언트에 전송
```

#### 3. **DTO 클래스 추가**

**GPTResponse.java**
```
👽 새로 생성

구조:
- List<Choice> choices
  - Choice.index: 응답 인덱스
  - Choice.message: Message 객체
    - message.content: 실제 응답 텍스트

목적: OpenAI API의 응답을 자바 객체로 매핑
```

**FeedbackMessage.java**
```
👽 새로 생성

필드:
- String msgText: 피드백을 요청할 텍스트
- String feedbackType: "grammar" | "vocabulary" | "formal / informal"
- String msgId: 해당 메시지의 ID (피드백 저장 시 참조)

목적: 웹소켓으로 전송된 피드백 요청을 파싱
```

#### 4. **Configuration 설정**
```
application.yml에 추가:
  openai:
    api:
      url: https://api.openai.com/v1/chat/completions
      key: ${OPENAI_API_KEY}  # 환경변수에서 주입
      model:
        chat: gpt-3.5-turbo
        feedback: gpt-3.5-turbo
```

#### 5. **통신 흐름**

```
클라이언트 (웹소켓 텍스트 메시지)
    ↓
{
  "msgText": "사용자 문장",
  "feedbackType": "grammar",
  "msgId": "msg-123"
}
    ↓
SocketVoiceHandler.handleTextMessage()
    ↓
FeedbackMessage 파싱
    ↓
gptService.handleFeedbackGPT()
    ↓
OpenAI API 호출
    ↓
GPTResponse 수신
    ↓
Feedback 객체 생성/업데이트
    ↓
필터링된 응답 클라이언트 전송
```

### 🔥 주요 특징

- **API 분리**: 일반 응답과 피드백을 별도 메서드로 관리
- **타입별 프롬프트**: 문법/어휘/존댓말 각각 전문적인 System Prompt
- **중복 방지**: 동일 msgId에 대한 피드백은 한 번만 저장
- **확장성**: 새로운 피드백 타입 추가 용이 (switch-case 확장)
