### PR TITLE
[feat] 채팅방 GPT Feedback 호출, 응답 기능

### DIFF
--- a/src/main/java/com/nuri/nuribackend/domain/Feedback/Feedback.java
+++ b/src/main/java/com/nuri/nuribackend/domain/Feedback/Feedback.java
@@ -2,6 +2,7 @@ package com.nuri.nuribackend.domain.Feedback;
 
 import jakarta.persistence.Id;
 import lombok.Data;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "feedback")
@@ -11,10 +12,11 @@ public class Feedback {
     @Id
     private String id;
 
+    @Indexed
     private String msgId;   // chatMessage 의 id의 값임(조회시 필요함)
 
     private FeedbackContent grammar;
     private FeedbackContent vocabulary;
     private FeedbackContent ageInGroup;
-    private FeedbackContent FormalInformal;
+    private FeedbackContent formalInformal;
 }

--- a/src/main/java/com/nuri/nuribackend/domain/Feedback/FeedbackContent.java
+++ b/src/main/java/com/nuri/nuribackend/domain/Feedback/FeedbackContent.java
@@ -1,7 +1,11 @@
 package com.nuri.nuribackend.domain.Feedback;
 
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Data;
 
+@AllArgsConstructor
+@NoArgsConstructor
 @Data
 public class FeedbackContent {
 

--- a/src/main/java/com/nuri/nuribackend/dto/GPT/FeedbackMessage.java
+++ b/src/main/java/com/nuri/nuribackend/dto/GPT/FeedbackMessage.java
@@ -1,0 +1,14 @@
+package com.nuri.nuribackend.dto.GPT;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FeedbackMessage {
+    private String msgText;       // 메시지 내용
+    private String feedbackType;  // 피드백 타입 (grammar, vocabulary, formalInformal)
+    private String msgId;         // 메시지 ID (피드백 대상이 될 말풍선의 ID)
+}

--- a/src/main/java/com/nuri/nuribackend/service/GPTService.java
+++ b/src/main/java/com/nuri/nuribackend/service/GPTService.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nuri.nuribackend.domain.ChatMessage;
 import com.nuri.nuribackend.dto.GPT.GPTResponse;
 import com.nuri.nuribackend.repository.ChatMessageRepository;
+import com.nuri.nuribackend.domain.Feedback.Feedback;
+import com.nuri.nuribackend.domain.Feedback.FeedbackContent;
+import com.nuri.nuribackend.repository.FeedbackRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -26,15 +30,19 @@ public class GPTService {
     private final RestTemplate restTemplate;
     private final ObjectMapper mapper;
     private final ChatMessageRepository chatMessageRepository;
+    private final FeedbackRepository feedbackRepository;
 
     @Value("${openai.api.url}")
     private String apiUrl;
 
-    @Value("${openai.api.model}")
+    @Value("${openai.api.model.chat}")
     private String model;
 
     @Value("${openai.api.key}")
     private String apiKey;
+
+    @Value("${openai.api.model.feedback}")
+    private String modelFeedback;
 
     public ChatMessage handleTextGPT(String result) {
         // 사용자 메시지 설정
@@ -82,10 +90,78 @@ public class GPTService {
                 log.error("GPT API에서 응답이 없습니다.");
                 return null;
             }
-            } catch (Exception e) {
-                log.error("GPT API 호출 중 오류가 발생했습니다.", e);
-                return null;
-            }
+        } catch (Exception e) {
+            log.error("GPT API 호출 중 오류가 발생했습니다.", e);
+            return null;
+        }
 
     }
+
+    // 피드백 요청 처리
+    public Feedback handleFeedbackGPT(String msgId, String msgText, String feedbackType) {
+        // 피드백 항목별 system 메시지 설정
+        String systemMessage = switch (feedbackType.toLowerCase()) {
+            case "grammar" -> "You are an expert in Korean grammar. Analyze the given sentence and identify any grammatical errors or unnatural usage. Provide detailed feedback in English, explaining why these are errors and how they can be improved. If the sentence is appropriate, respond with 'There are no errors. The sentence is correct.'";
+            case "vocabulary" -> "You are an expert in Korean vocabulary. Analyze the vocabulary used in the given sentence. Identify any incorrect or unnatural word choices and provide suggestions for improvement. Explain the corrections in English. If the sentence is appropriate, respond with 'There are no errors. The sentence is correct.'";
+            case "formal / informal" -> "You are an expert in Korean language formality. Analyze whether the user's last sentence aligns with the appropriate level of formality (formal or informal) based on the context provided in the preceding conversation. If the level of formality is appropriate, respond with 'There are no errors. The sentence is correct' If adjustments are needed, explain the issues and provide suggestions for improvement in English.";
+            default -> throw new IllegalArgumentException("Invalid feedback type: " + feedbackType);
+        };
+
+        Map<String, String> system = Map.of("role", "system", "content", systemMessage);
+        Map<String, String> user = Map.of("role", "user", "content", msgText);
+        List<Map<String, String>> messages = List.of(system, user);
+
+        Map<String, Object> gptRequest = Map.of(
+                "model", modelFeedback,
+                "messages", messages,
+                "max_tokens", 256,
+                "temperature", 0.7,
+                "top_p", 0.7
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "Bearer " + apiKey);
+
+        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(gptRequest, headers);
+
+        try {
+            GPTResponse gptResponse = restTemplate.postForObject(apiUrl, requestEntity, GPTResponse.class);
+
+            if (gptResponse != null && gptResponse.getChoices() != null && !gptResponse.getChoices().isEmpty()) {
+                String gptReply = gptResponse.getChoices().get(0).getMessage().getContent();
+
+                // 기존 데이터 조회
+                Optional<Feedback> existingFeedback = feedbackRepository.findById(msgId);
+                Feedback feedback;
+
+                if (existingFeedback.isPresent()) {
+                    feedback = existingFeedback.get(); // 기존 데이터 가져오기 (중복 저장 방지)
+                } else {
+                    feedback = new Feedback(); // 새 객체 생성
+                    feedback.setId(msgId);     // ID 설정
+                }
+
+                // FeedbackContent 객체 생성 (피드백 내용)
+                FeedbackContent feedbackContent = new FeedbackContent(gptReply);
+
+                switch (feedbackType.toLowerCase()) {
+                    case "grammar" -> feedback.setGrammar(feedbackContent);
+                    case "vocabulary" -> feedback.setVocabulary(feedbackContent);
+                    case "formal / informal" -> feedback.setFormalInformal(feedbackContent);
+                    default -> throw new IllegalArgumentException("Invalid feedback type: " + feedbackType);
+                }
+
+                return feedback;
+
+            } else {
+                log.error("GPT API에서 응답이 없습니다.");
+                return null;
+            }
+        } catch (Exception e) {
+            log.error("GPT API 호출 중 오류가 발생했습니다.", e);
+            return null;
+        }
+    }
+
 }


### PR DESCRIPTION
### resolved: #16 

---

### 📝 주요 수정 사항

#### 1. **SocketVoiceHandler.java - 텍스트 메시지 핸들링** (수정)
```
handleTextMessage() 메서드 구현

핵심 로직:
  1. JSON 페이로드 파싱
     - FeedbackMessage 객체로 변환
     - msgText, msgId, feedbackType 추출

  2. GPT 피드백 생성
     - gptService.handleFeedbackGPT() 호출
     - 해당 msgId에 대한 피드백 생성

  3. 응답 필터링
     - feedbackType에 따라 해당 피드백만 추출
     - grammar | vocabulary | formal/informal 중 선택

  4. 클라이언트 전송
     - 필터링된 피드백만 JSON으로 변환
     - 웹소켓을 통해 실시간 전송

  5. DB 저장
     - feedbackRepository.save()로 MongoDB에 저장
     - 향후 월별 피드백 생성시 참조
```

#### 2. **GPTService.java - 피드백 로직 확장** (기존 코드 유지)
```
handleFeedbackGPT()

추가된 기능:
  - 피드백 저장소 통합 (feedbackRepository)
  - 중복 저장 방지 로직 강화
  - FeedbackContent 객체 생성 및 저장
```

#### 3. **데이터 저장 구조**

**Feedback.java (MongoDB Document)**
```
@Document(collection = "feedback")
- id: MongoDB ObjectId
- msgId: 피드백 대상 메시지 ID (인덱싱)
- grammar: FeedbackContent (문법 피드백)
- vocabulary: FeedbackContent (어휘 피드백)
- FormalInformal: FeedbackContent (존댓말 피드백)
```

**FeedbackContent.java**
```
- content: 실제 피드백 텍스트 (GPT 응답)
```

#### 4. **통신 흐름 (텍스트 메시지)**

```
클라이언트
    ↓
WebSocket 텍스트 메시지
{
  "msgText": "사용자 문장",
  "feedbackType": "grammar",
  "msgId": "msg-123"
}
    ↓
handleTextMessage() 수신
    ↓
FeedbackMessage 파싱
    ↓
gptService.handleFeedbackGPT(msgId, msgText, feedbackType)
    ↓
OpenAI API 호출
    ↓
GPT 응답 수신
    ↓
Feedback 객체 생성
    ↓
feedbackRepository.save() → MongoDB 저장
    ↓
filteredFeedback 추출 (요청한 타입만)
    ↓
JSON 변환 및 클라이언트 전송
```

#### 5. **주요 특징**
- **타입별 관리**: 문법/어휘/존댓말 각각 독립적으로 관리
- **선택적 응답**: 클라이언트 요청한 타입만 전송 (트래픽 최적화)
- **데이터 영속성**: MongoDB에 저장하여 월별 피드백 생성에 활용


